### PR TITLE
Update to Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ target/
 public/
 .env
 .klasses.json
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+  - "3.8"
 install:
   - pip install -r requirements-test.txt
   - pip install pytest-cov

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [Django REST framework](http://www.django-rest-framework.org) is a powerful and flexible toolkit that makes it easy to build Web APIs. It provides class based generic API views and serializers. We've taken all the attributes and methods that every view/serializer defines or inherits, and flattened all that information onto one comprehensive page per class. This project is heavily based on [Classy Class-Based Views](http://ccbv.co.uk) and was developed by [Vinta Software Studio](http://www.vinta.com.br).
 
 ## Dependencies
-* Python 2.7
+* Python 3.8+
 * s3cmd (For deploy)
 
 ## Building

--- a/build.ini
+++ b/build.ini
@@ -1,65 +1,13 @@
 [tox]
 skipsdist=True
-envlist = drf{21,22,23,24,30,31,32,33,34,35,36,37,38,39},drfbuild{21,22,23,24,30,31,32,33,34,35,36,37,38,39}
+envlist = drf{312},drfbuild{312}
 
 [testenv]
 deps=
     -r{toxinidir}/requirements-tox.txt
-deps21 =
-    django==1.8.13
-    djangorestframework>=2.1,<2.2
-
-deps22 =
-    django==1.8.13
-    djangorestframework>=2.2,<2.3
-
-deps23 =
-    django==1.8.13
-    djangorestframework>=2.3,<2.4
-
-deps24 =
-    django==1.8.13
-    djangorestframework>=2.4,<2.5
-
-deps30 =
-    django==1.8.13
-    djangorestframework>=3.0,<3.1
-
-deps31 =
-    django==1.11.17
-    djangorestframework>=3.1,<3.2
-
-deps32 =
-    django==1.11.17
-    djangorestframework>=3.2,<3.3
-
-deps33 =
-    django==1.11.17
-    djangorestframework>=3.3,<3.4
-
-deps34 =
-    django==1.11.17
-    djangorestframework>=3.4,<3.5
-
-deps35 =
-    django==1.11.17
-    djangorestframework>=3.5,<3.6
-
-deps36 =
-    django==1.11.17
-    djangorestframework>=3.6,<3.7
-
-deps37 =
-    django==1.11.17
-    djangorestframework>=3.7,<3.8
-
-deps38 =
-    django==1.11.17
-    djangorestframework>=3.8,<3.9
-
-deps39 =
-    django==1.11.17
-    djangorestframework>=3.9,<3.10
+deps312 =
+    django==3.2
+    djangorestframework>=3.12,<3.13
 
 setenv =
     PYTHONPATH = {toxinidir}
@@ -69,221 +17,26 @@ setenv =
 
 [index]
 commands =
-    fab index_generator_for_version
+    fab index
 
 [build]
 commands =
-    fab build_for_version
+    fab version
 
-[testenv:drf21]
+[testenv:drf312]
 deps =
     {[testenv]deps}
-    {[testenv]deps21}
-commands =
-    {[index]commands}
-
-[testenv:drf22]
-deps =
-    {[testenv]deps}
-    {[testenv]deps22}
-commands =
-    {[index]commands}
-
-[testenv:drf23]
-deps =
-    {[testenv]deps}
-    {[testenv]deps23}
-commands =
-    {[index]commands}
-
-[testenv:drf24]
-deps =
-    {[testenv]deps}
-    {[testenv]deps24}
-commands =
-    {[index]commands}
-
-[testenv:drf30]
-deps =
-    {[testenv]deps}
-    {[testenv]deps30}
-commands =
-    {[index]commands}
-
-[testenv:drf31]
-deps =
-    {[testenv]deps}
-    {[testenv]deps31}
-commands =
-    {[index]commands}
-
-[testenv:drf32]
-deps =
-    {[testenv]deps}
-    {[testenv]deps32}
-commands =
-    {[index]commands}
-
-[testenv:drf33]
-deps =
-    {[testenv]deps}
-    {[testenv]deps33}
-commands =
-    {[index]commands}
-
-[testenv:drf34]
-deps =
-    {[testenv]deps}
-    {[testenv]deps34}
-commands =
-    {[index]commands}
-
-[testenv:drf35]
-deps =
-    {[testenv]deps}
-    {[testenv]deps35}
-commands =
-    {[index]commands}
-
-[testenv:drf36]
-deps =
-    {[testenv]deps}
-    {[testenv]deps36}
-commands =
-    {[index]commands}
-
-[testenv:drf37]
-deps =
-    {[testenv]deps}
-    {[testenv]deps37}
-commands =
-    {[index]commands}
-
-[testenv:drf38]
-deps =
-    {[testenv]deps}
-    {[testenv]deps38}
-commands =
-    {[index]commands}
-
-[testenv:drf39]
-deps =
-    {[testenv]deps}
-    {[testenv]deps39}
+    {[testenv]deps312}
 commands =
     {[index]commands}
 
 
 # SITE GENERATION
 
-[testenv:drfbuild21]
+[testenv:drfbuild312]
 deps =
-    {[testenv:drf21]deps}
+    {[testenv:drf312]deps}
 envdir =
-    {toxworkdir}/drf21
-commands =
-    {[build]commands}
-
-[testenv:drfbuild22]
-deps =
-    {[testenv:drf22]deps}
-envdir =
-    {toxworkdir}/drf22
-commands =
-    {[build]commands}
-
-[testenv:drfbuild23]
-deps =
-    {[testenv:drf23]deps}
-envdir =
-    {toxworkdir}/drf23
-commands =
-    {[build]commands}
-
-[testenv:drfbuild24]
-deps =
-    {[testenv:drf24]deps}
-envdir =
-    {toxworkdir}/drf24
-commands =
-    {[build]commands}
-
-[testenv:drfbuild30]
-deps =
-    {[testenv:drf30]deps}
-envdir =
-    {toxworkdir}/drf30
-commands =
-    {[build]commands}
-
-[testenv:drfbuild31]
-deps =
-    {[testenv:drf31]deps}
-envdir =
-    {toxworkdir}/drf31
-commands =
-    {[build]commands}
-
-[testenv:drfbuild32]
-deps =
-    {[testenv:drf32]deps}
-envdir =
-    {toxworkdir}/drf32
-commands =
-    {[build]commands}
-
-[testenv:drfbuild33]
-deps =
-    {[testenv:drf33]deps}
-envdir =
-    {toxworkdir}/drf33
-commands =
-    {[build]commands}
-
-[testenv:drfbuild34]
-deps =
-    {[testenv:drf34]deps}
-envdir =
-    {toxworkdir}/drf34
-commands =
-    {[build]commands}
-
-[testenv:drfbuild35]
-deps =
-    {[testenv:drf35]deps}
-envdir =
-    {toxworkdir}/drf35
-commands =
-    {[build]commands}
-
-[testenv:drfbuild36]
-deps =
-    {[testenv:drf36]deps}
-envdir =
-    {toxworkdir}/drf36
-commands =
-    {[build]commands}
-
-[testenv:drfbuild37]
-deps =
-    {[testenv:drf37]deps}
-envdir =
-    {toxworkdir}/drf37
-commands =
-    {[build]commands}
-
-[testenv:drfbuild38]
-deps =
-    {[testenv:drf38]deps}
-envdir =
-    {toxworkdir}/drf38
-commands =
-    {[build]commands}
-
-[testenv:drfbuild39]
-deps =
-    {[testenv:drf39]deps}
-envdir =
-    {toxworkdir}/drf39
+    {toxworkdir}/drf312
 commands =
     {[build]commands}

--- a/build.ini
+++ b/build.ini
@@ -1,33 +1,35 @@
 [tox]
 skipsdist=True
-envlist = drf{31,32,33,34,35,36,37,38,39,310,311,312},drfbuild{31,32,33,34,35,36,37,38,39,310,311,312}
+envlist =
+    drf{31,32,33,34,35,36,37,38,39,310,311,312},
+    drfbuild{31,32,33,34,35,36,37,38,39,310,311,312},
 
 [testenv]
-deps=
+deps =
     -r{toxinidir}/requirements-tox.txt
 
 deps31 =
-    django==1.11.17
+    django==1.11.29
     djangorestframework>=3.1,<3.2
 
 deps32 =
-    django==1.11.17
+    django==1.11.29
     djangorestframework>=3.2,<3.3
 
 deps33 =
-    django==1.11.17
+    django==1.11.29
     djangorestframework>=3.3,<3.4
 
 deps34 =
-    django==1.11.17
+    django==1.11.29
     djangorestframework>=3.4,<3.5
 
 deps35 =
-    django==1.11.17
+    django==1.11.29
     djangorestframework>=3.5,<3.6
 
 deps36 =
-    django==1.11.17
+    django==1.11.29
     djangorestframework>=3.6,<3.7
 
 deps37 =

--- a/build.ini
+++ b/build.ini
@@ -1,10 +1,55 @@
 [tox]
 skipsdist=True
-envlist = drf{312},drfbuild{312}
+envlist = drf{31,32,33,34,35,36,37,38,39,310,311,312},drfbuild{31,32,33,34,35,36,37,38,39,310,311,312}
 
 [testenv]
 deps=
     -r{toxinidir}/requirements-tox.txt
+
+deps31 =
+    django==1.11.17
+    djangorestframework>=3.1,<3.2
+
+deps32 =
+    django==1.11.17
+    djangorestframework>=3.2,<3.3
+
+deps33 =
+    django==1.11.17
+    djangorestframework>=3.3,<3.4
+
+deps34 =
+    django==1.11.17
+    djangorestframework>=3.4,<3.5
+
+deps35 =
+    django==1.11.17
+    djangorestframework>=3.5,<3.6
+
+deps36 =
+    django==1.11.17
+    djangorestframework>=3.6,<3.7
+
+deps37 =
+    django==2.2
+    djangorestframework>=3.7,<3.8
+
+deps38 =
+    django==2.2
+    djangorestframework>=3.8,<3.9
+
+deps39 =
+    django==2.2
+    djangorestframework>=3.9,<3.10
+
+deps310 =
+    django==2.2
+    djangorestframework>=3.10,<3.11
+
+deps311 =
+    django==3.2
+    djangorestframework>=3.11,<3.12
+
 deps312 =
     django==3.2
     djangorestframework>=3.12,<3.13
@@ -23,6 +68,83 @@ commands =
 commands =
     fab version
 
+[testenv:drf31]
+deps =
+    {[testenv]deps}
+    {[testenv]deps31}
+commands =
+    {[index]commands}
+
+[testenv:drf32]
+deps =
+    {[testenv]deps}
+    {[testenv]deps32}
+commands =
+    {[index]commands}
+
+[testenv:drf33]
+deps =
+    {[testenv]deps}
+    {[testenv]deps33}
+commands =
+    {[index]commands}
+
+[testenv:drf34]
+deps =
+    {[testenv]deps}
+    {[testenv]deps34}
+commands =
+    {[index]commands}
+
+[testenv:drf35]
+deps =
+    {[testenv]deps}
+    {[testenv]deps35}
+commands =
+    {[index]commands}
+
+[testenv:drf36]
+deps =
+    {[testenv]deps}
+    {[testenv]deps36}
+commands =
+    {[index]commands}
+
+[testenv:drf37]
+deps =
+    {[testenv]deps}
+    {[testenv]deps37}
+commands =
+    {[index]commands}
+
+[testenv:drf38]
+deps =
+    {[testenv]deps}
+    {[testenv]deps38}
+commands =
+    {[index]commands}
+
+[testenv:drf39]
+deps =
+    {[testenv]deps}
+    {[testenv]deps39}
+commands =
+    {[index]commands}
+
+[testenv:drf310]
+deps =
+    {[testenv]deps}
+    {[testenv]deps310}
+commands =
+    {[index]commands}
+
+[testenv:drf311]
+deps =
+    {[testenv]deps}
+    {[testenv]deps311}
+commands =
+    {[index]commands}
+
 [testenv:drf312]
 deps =
     {[testenv]deps}
@@ -32,6 +154,94 @@ commands =
 
 
 # SITE GENERATION
+
+[testenv:drfbuild31]
+deps =
+    {[testenv:drf31]deps}
+envdir =
+    {toxworkdir}/drf31
+commands =
+    {[build]commands}
+
+[testenv:drfbuild32]
+deps =
+    {[testenv:drf32]deps}
+envdir =
+    {toxworkdir}/drf32
+commands =
+    {[build]commands}
+
+[testenv:drfbuild33]
+deps =
+    {[testenv:drf33]deps}
+envdir =
+    {toxworkdir}/drf33
+commands =
+    {[build]commands}
+
+[testenv:drfbuild34]
+deps =
+    {[testenv:drf34]deps}
+envdir =
+    {toxworkdir}/drf34
+commands =
+    {[build]commands}
+
+[testenv:drfbuild35]
+deps =
+    {[testenv:drf35]deps}
+envdir =
+    {toxworkdir}/drf35
+commands =
+    {[build]commands}
+
+[testenv:drfbuild36]
+deps =
+    {[testenv:drf36]deps}
+envdir =
+    {toxworkdir}/drf36
+commands =
+    {[build]commands}
+
+[testenv:drfbuild37]
+deps =
+    {[testenv:drf37]deps}
+envdir =
+    {toxworkdir}/drf37
+commands =
+    {[build]commands}
+
+[testenv:drfbuild38]
+deps =
+    {[testenv:drf38]deps}
+envdir =
+    {toxworkdir}/drf38
+commands =
+    {[build]commands}
+
+[testenv:drfbuild39]
+deps =
+    {[testenv:drf39]deps}
+envdir =
+    {toxworkdir}/drf39
+commands =
+    {[build]commands}
+
+[testenv:drfbuild310]
+deps =
+    {[testenv:drf310]deps}
+envdir =
+    {toxworkdir}/drf310
+commands =
+    {[build]commands}
+
+[testenv:drfbuild311]
+deps =
+    {[testenv:drf311]deps}
+envdir =
+    {toxworkdir}/drf311
+commands =
+    {[build]commands}
 
 [testenv:drfbuild312]
 deps =

--- a/build_tools/index_generator.py
+++ b/build_tools/index_generator.py
@@ -15,7 +15,7 @@ def main():
     klasses = sorted(drfklasses.values(), key=lambda x: x.__module__)
 
     for key, value in groupby(klasses, lambda x: x.__module__):
-        d_version[key] = map(lambda x: x.__name__, list(value))
+        d_version[key] = list(map(lambda x: x.__name__, list(value)))
 
     if os.path.isfile('.klasses.json'):
         with open('.klasses.json', 'r') as f:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 -r requirements-tox.txt
-djangorestframework==3.9
-django==1.11.17
-mock==2.0.0
-pytest==2.6.4
+djangorestframework==3.12.4
+django==3.2
+mock==4.0.3
+pytest==6.2.3

--- a/requirements-tox.txt
+++ b/requirements-tox.txt
@@ -1,5 +1,5 @@
-Fabric==1.10.1
-Jinja2==2.7.3
-Pygments==2.0.2
-python-decouple==2.3
+Fabric==2.6.0
+Jinja2==2.11.3
+Pygments==2.8.1
+python-decouple==3.4
 pycrypto==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Fabric==1.10.1
-python-decouple==2.3
+Fabric==2.6.0
+python-decouple==3.4
 pycrypto==2.6.1
-tox==1.9.0
+tox==3.23.0

--- a/rest_framework_ccbv/config.py
+++ b/rest_framework_ccbv/config.py
@@ -2,20 +2,7 @@ from rest_framework import VERSION as rest_framework_version
 
 
 REST_FRAMEWORK_VERSIONS = [
-    '2.1',
-    '2.2',
-    '2.3',
-    '2.4',
-    '3.0',
-    '3.1',
-    '3.2',
-    '3.3',
-    '3.4',
-    '3.5',
-    '3.6',
-    '3.7',
-    '3.8',
-    '3.9',
+    '3.12',
 ]
 
 

--- a/rest_framework_ccbv/config.py
+++ b/rest_framework_ccbv/config.py
@@ -2,6 +2,17 @@ from rest_framework import VERSION as rest_framework_version
 
 
 REST_FRAMEWORK_VERSIONS = [
+    '3.1',
+    '3.2',
+    '3.3',
+    '3.4',
+    '3.5',
+    '3.6',
+    '3.7',
+    '3.8',
+    '3.9',
+    '3.10',
+    '3.11',
     '3.12',
 ]
 

--- a/rest_framework_ccbv/inspector.py
+++ b/rest_framework_ccbv/inspector.py
@@ -12,6 +12,8 @@ except ImportError:
 from rest_framework.compat import View
 from rest_framework import serializers
 from rest_framework.serializers import BaseSerializer
+from rest_framework import pagination
+from rest_framework.pagination import BasePagination
 from pygments import highlight, lex
 from pygments.lexers import PythonLexer
 from pygments.token import Token
@@ -25,7 +27,7 @@ def add_to_klasses_if_its_restframework(klasses, klass):
 
 
 def get_klasses():
-    modules = [rest_views, generics, serializers]
+    modules = [rest_views, generics, serializers, pagination]
 
     if viewsets is not None:
         modules.append(viewsets)
@@ -36,8 +38,10 @@ def get_klasses():
             is_subclass = False
             attr = getattr(module, attr_str)
             try:
-                is_subclass = (issubclass(attr, View) or
-                               issubclass(attr, BaseSerializer))
+                is_subclass = issubclass(
+                    attr,
+                    (View, BaseSerializer, BasePagination)
+                )
             except TypeError:
                 pass
             if not attr_str.startswith('_') and is_subclass:

--- a/rest_framework_ccbv/inspector.py
+++ b/rest_framework_ccbv/inspector.py
@@ -15,7 +15,7 @@ from rest_framework.serializers import BaseSerializer
 from pygments import highlight, lex
 from pygments.lexers import PythonLexer
 from pygments.token import Token
-from custom_formatter import CodeHtmlFormatter
+from .custom_formatter import CodeHtmlFormatter
 
 
 def add_to_klasses_if_its_restframework(klasses, klass):
@@ -103,7 +103,7 @@ class Attributes(collections.MutableSequence):
         if not isinstance(value, Attribute):
             raise TypeError('Can only hold Attributes')
         # find attributes higher in the mro
-        existing = filter(lambda x: x.name == value.name, self.attrs)
+        existing = list(filter(lambda x: x.name == value.name, self.attrs))
         # methods can't be dirty, because they don't necessarily override
         if existing and not isinstance(value, Method):
             value.dirty = True

--- a/rest_framework_ccbv/inspector.py
+++ b/rest_framework_ccbv/inspector.py
@@ -147,17 +147,24 @@ class Inspector(object):
                 children.append(klass)
         return children
 
+    def _is_method(self, attr):
+        return isinstance(attr, (types.FunctionType, types.MethodType))
+
     def get_attributes(self):
         attrs = Attributes()
 
         for klass in self.get_klass_mro():
             for attr_str in klass.__dict__.keys():
                 attr = getattr(klass, attr_str)
-                if (not attr_str.startswith('__') and
-                        not isinstance(attr, types.MethodType)):
-                    attrs.append(Attribute(name=attr_str, value=attr,
-                                           classobject=klass,
-                                           instance_class=self.get_klass()))
+                if (not attr_str.startswith('__') and not self._is_method(attr)):
+                    attrs.append(
+                        Attribute(
+                            name=attr_str,
+                            value=attr,
+                            classobject=klass,
+                            instance_class=self.get_klass(),
+                        )
+                    )
         return attrs
 
     def get_methods(self):
@@ -166,12 +173,15 @@ class Inspector(object):
         for klass in self.get_klass_mro():
             for attr_str in klass.__dict__.keys():
                 attr = getattr(klass, attr_str)
-                if (not attr_str.startswith('__') and
-                        isinstance(attr, types.MethodType)):
-                    attrs.append(Method(name=attr_str,
-                                 value=attr,
-                                 classobject=klass,
-                                 instance_class=self.get_klass()))
+                if (not attr_str.startswith('__') and self._is_method(attr)):
+                    attrs.append(
+                        Method(
+                            name=attr_str,
+                            value=attr,
+                            classobject=klass,
+                            instance_class=self.get_klass(),
+                        )
+                    )
         return attrs
 
     def get_direct_ancestors(self):

--- a/rest_framework_ccbv/inspector.py
+++ b/rest_framework_ccbv/inspector.py
@@ -70,9 +70,9 @@ class Method(Attribute):
 
     def params_string(self):
         stack = []
-        argspec = inspect.getargspec(self.value)
-        if argspec.keywords:
-            stack.insert(0, '**' + argspec.keywords)
+        argspec = inspect.getfullargspec(self.value)
+        if argspec.varkw:
+            stack.insert(0, '**' + argspec.varkw)
         if argspec.varargs:
             stack.insert(0, '*' + argspec.varargs)
         defaults = list(argspec.defaults or [])
@@ -89,7 +89,7 @@ class Method(Attribute):
         return highlight(code, PythonLexer(), CodeHtmlFormatter(self.instance_class))
 
 
-class Attributes(collections.MutableSequence):
+class Attributes(collections.abc.MutableSequence):
     # Attributes must be added following mro order
     def __init__(self):
         self.attrs = []

--- a/rest_framework_ccbv/jinja_utils.py
+++ b/rest_framework_ccbv/jinja_utils.py
@@ -4,7 +4,7 @@ from rest_framework.serializers import BaseSerializer
 from rest_framework.compat import View
 from jinja2 import contextfunction, FileSystemLoader, Environment
 
-from config import VERSION, EXACT_VERSION
+from .config import VERSION, EXACT_VERSION
 
 templateLoader = FileSystemLoader(searchpath="templates")
 templateEnv = Environment(loader=templateLoader,

--- a/rest_framework_ccbv/renderers.py
+++ b/rest_framework_ccbv/renderers.py
@@ -1,10 +1,8 @@
-
 import json
 
-from inspector import Inspector
-from jinja_utils import templateEnv
-from config import REST_FRAMEWORK_VERSIONS, VERSION, BASE_URL
-from itertools import ifilter
+from .inspector import Inspector
+from .jinja_utils import templateEnv
+from .config import REST_FRAMEWORK_VERSIONS, VERSION, BASE_URL
 
 
 class BasePageRenderer(object):
@@ -52,8 +50,7 @@ class DetailPageRenderer(BasePageRenderer):
         context['attributes'] = self.inspector.get_attributes()
         context['methods'] = self.inspector.get_methods()
 
-        context['this_klass'] = next(
-            ifilter(lambda x: x.__name__ == self.klass, self.klasses))
+        context['this_klass'] = next(filter(lambda x: x.__name__ == self.klass, self.klasses))
 
         context['children'] = self.inspector.get_children()
         context['this_module'] = context['this_klass'].__module__

--- a/rest_framework_ccbv/renderers.py
+++ b/rest_framework_ccbv/renderers.py
@@ -13,7 +13,7 @@ class BasePageRenderer(object):
         for klass in klasses:
             module = klass.__module__
             grouped_klasses[module].append(klass)
-        self.grouped_klasses = grouped_klasses
+        self.grouped_klasses = dict(grouped_klasses)
 
     def render(self, filename):
         template = templateEnv.get_template(self.template_name)

--- a/rest_framework_ccbv/renderers.py
+++ b/rest_framework_ccbv/renderers.py
@@ -14,7 +14,7 @@ class BasePageRenderer(object):
         template = templateEnv.get_template(self.template_name)
         context = self.get_context()
         with open(filename, 'w') as f:
-            f.write(template.render(context).encode("UTF-8"))
+            f.write(template.render(context))
 
     def get_context(self):
         other_versions = list(REST_FRAMEWORK_VERSIONS)

--- a/templates/_klass_list.html
+++ b/templates/_klass_list.html
@@ -1,18 +1,17 @@
 <div class="span{{ column_width }}">
-    {% for klass in klasses %}
-    {% if current_module !=  klass.__module__  or loop.first %}
-        {% if not loop.first %}</ul></div>{% endif %}
-        {% if klass.__module__.split('.')[-1] == 'serializers' %}</div><div class="span{{ column_width }}">{% endif %}
-        <div class="well skinny klass-list">
+    {% for module, klasses in grouped_klasses.items() %}
+    {% if module.split('.')[-1] == 'serializers' %}</div><div class="span{{ column_width }}">{% endif %}
+    <div class="well skinny klass-list">
         <ul class="nav nav-list">
-        <li class="nav-header"><h3>{{ klass.__module__.split('.')[-1] }}</h3></li>
-        {% set current_module = klass.__module__ %}
-    {% endif %}
-    <li class="primary">
-        <a href="{{ get_klass_url(klass) }}" {% if get_klass_docs(klass) %}class="klass-tooltip" data-original-title="{{ get_klass_docs(klass) }}" data-placement="bottom"{% endif %}>
-            {{ klass.__name__ }}
-        </a>
-    </li>
+            <li class="nav-header"><h3>{{ module.split('.')[-1] }}</h3></li>
+            {% for klass in klasses %}
+            <li class="primary">
+                <a href="{{ get_klass_url(klass) }}" {% if get_klass_docs(klass) %}class="klass-tooltip" data-original-title="{{ get_klass_docs(klass) }}" data-placement="bottom"{% endif %}>
+                    {{ klass.__name__ }}
+                </a>
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
     {% endfor %}
-</ul></div>
 </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -55,22 +55,22 @@
                 </li>
 
                 <li class="divider-vertical"></li>
-                {% for klass in klasses %}
-                    {% if current_module != klass.__module__ or loop.first %}
-                        {% if not loop.first %}</ul></li>{% endif %}
-                        {% set module_short_name = klass.__module__.split('.')[-1] %}
-                        <li id="module-{{ module_short_name }}" class="dropdown{% if klass.__module__ == this_module %} active{% endif %}">
-                        <a href="#module-{{ module_short_name }}" class="dropdown-toggle" data-toggle="dropdown">
-                            {{ module_short_name|title }} <b class="caret"></b>
-                        </a>
-                        <ul class="dropdown-menu">
-                    {% endif %}
-                    <li {% if klass == this_klass %}class=" active"{% endif %}>
-                        <a href="{{ get_klass_url(klass) }}">{{ klass.__name__ }}</a>
-                    </li>
-                    {% set current_module = klass.__module__ %}
+
+                {% for module, klasses in grouped_klasses.items() %}
+                <li id="module-{{ module.split('.')[-1] }}" class="dropdown{% if module == this_module %} active{% endif %}">
+                    <a href="#module-{{ module.split('.')[-1] }}" class="dropdown-toggle" data-toggle="dropdown">
+                        {{ module.split('.')[-1]|title }} <b class="caret"></b>
+                    </a>
+                    <ul class="dropdown-menu">
+                        {% for klass in klasses %}
+                        <li {% if klass == this_klass %}class=" active"{% endif %}>
+                            <a href="{{ get_klass_url(klass) }}">{{ klass.__name__ }}</a>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </li>
                 {% endfor %}
-                </ul></li>
+
                 {% endblock nav %}
                 </ul>
             </div>

--- a/templates/sitemap.xml
+++ b/templates/sitemap.xml
@@ -3,8 +3,8 @@
         <loc>{{ base_url }}/</loc>
         <priority>1.0</priority>
     </url>
-    {% for version, modules in klasses.iteritems() %}
-        {% for module, methods in modules.iteritems() %}
+    {% for version, modules in klasses.items() %}
+        {% for module, methods in modules.items() %}
             {% for method in methods %}
                 <url>
                     <loc>{{ base_url }}/{{ version }}/{{ module }}/{{ method }}.html</loc>

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,20 +1,15 @@
-# -*- coding: utf-8 -*-
 """
     Most of the tests here are taken from Pygments since we had
     to replace the _format_lines method. Credits go to the authors.
 """
 
-from __future__ import print_function
-
-import io
 import os
 import re
 import unittest
 import tempfile
 import inspect
-from os.path import join, dirname, isfile
 
-from pygments.util import StringIO
+from io import StringIO
 from pygments.lexers import PythonLexer
 from pygments.formatters import NullFormatter
 from pygments.formatters.html import escape_html
@@ -79,17 +74,21 @@ class CodeHtmlFormatterTest(unittest.TestCase):
         self.assertTrue(re.search("<pre><a name=\"foo-5\">", html))
 
     def test_get_style_defs(self):
+        def fix_style_def(s):
+            # Removes styles that were added by default on newer pygments versions
+            return "\n".join(s.splitlines()[5:])
+
         fmt = CodeHtmlFormatter(instance_class=type)
         sd = fmt.get_style_defs()
-        self.assertTrue(sd.startswith('.'))
+        self.assertTrue(fix_style_def(sd).startswith('.'))
 
         fmt = CodeHtmlFormatter(instance_class=type, cssclass='foo')
         sd = fmt.get_style_defs()
-        self.assertTrue(sd.startswith('.foo'))
+        self.assertTrue(fix_style_def(sd).startswith('.foo'))
         sd = fmt.get_style_defs('.bar')
-        self.assertTrue(sd.startswith('.bar'))
+        self.assertTrue(fix_style_def(sd).startswith('.bar'))
         sd = fmt.get_style_defs(['.bar', '.baz'])
-        fl = sd.splitlines()[0]
+        fl = fix_style_def(sd).splitlines()[0]
         self.assertTrue('.bar' in fl and '.baz' in fl)
 
     def test_unicode_options(self):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -9,6 +9,7 @@ import unittest
 import tempfile
 import inspect
 
+from html import escape
 from io import StringIO
 from pygments.lexers import PythonLexer
 from pygments.formatters import NullFormatter
@@ -47,7 +48,7 @@ class CodeHtmlFormatterTest(unittest.TestCase):
         fmt = CodeHtmlFormatter(instance_class=type, **optdict)
         fmt.format(tokensource, outfile)
         html = outfile.getvalue()
-        self.assertTrue(re.search("<pre>\s+1\s+2\s+3", html))
+        self.assertTrue(re.search('<pre><span class="normal">\s+1</span>', html))
 
     def test_linenos_with_startnum(self):
         optdict = dict(linenos=True, linenostart=5)
@@ -55,7 +56,7 @@ class CodeHtmlFormatterTest(unittest.TestCase):
         fmt = CodeHtmlFormatter(instance_class=type, **optdict)
         fmt.format(tokensource, outfile)
         html = outfile.getvalue()
-        self.assertTrue(re.search("<pre>\s+5\s+6\s+7", html))
+        self.assertTrue(re.search('<pre><span class="normal">\s+5</span>', html))
 
     def test_lineanchors(self):
         optdict = dict(lineanchors="foo")
@@ -63,7 +64,7 @@ class CodeHtmlFormatterTest(unittest.TestCase):
         fmt = CodeHtmlFormatter(instance_class=type, **optdict)
         fmt.format(tokensource, outfile)
         html = outfile.getvalue()
-        self.assertTrue(re.search("<pre><a name=\"foo-1\">", html))
+        self.assertTrue(re.search('<pre><span></span><a name="foo-1">', html))
 
     def test_lineanchors_with_startnum(self):
         optdict = dict(lineanchors="foo", linenostart=5)
@@ -71,7 +72,7 @@ class CodeHtmlFormatterTest(unittest.TestCase):
         fmt = CodeHtmlFormatter(instance_class=type, **optdict)
         fmt.format(tokensource, outfile)
         html = outfile.getvalue()
-        self.assertTrue(re.search("<pre><a name=\"foo-5\">", html))
+        self.assertTrue(re.search('<pre><span></span><a name="foo-5">', html))
 
     def test_get_style_defs(self):
         def fix_style_def(s):
@@ -114,7 +115,7 @@ class CodeHtmlFormatterTest(unittest.TestCase):
         hfmt = CodeHtmlFormatter(instance_class=self.__class__, nowrap=True)
         houtfile = StringIO()
         hfmt.format(this_token_source, houtfile)
-        assert '<a href="#noop">noop</a>' in houtfile.getvalue()
+        assert escape('<a href="#noop">noop</a>') in houtfile.getvalue()
 
 
 tokensource = list(PythonLexer().get_tokens(

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -12,15 +12,15 @@ class TestInspector(unittest.TestCase):
         self.inspector = Inspector(self.klass, self.module)
 
     def test_get_klass(self):
-        self.assertEquals(self.inspector.get_klass(),
+        self.assertEqual(self.inspector.get_klass(),
                           getattr(generics, self.klass))
 
     def test_first_ancestor_is_itself(self):
-        self.assertEquals(self.inspector.get_klass_mro()[0].__name__,
+        self.assertEqual(self.inspector.get_klass_mro()[0].__name__,
                           self.klass)
 
     def test_ancestor(self):
-        self.assertEquals([x.__name__ for x in self.inspector.get_klass_mro()],
+        self.assertEqual([x.__name__ for x in self.inspector.get_klass_mro()],
                           [self.klass, 'APIView', 'View'])
 
     def test_attributes(self):

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -37,7 +37,7 @@ class TestInspector(unittest.TestCase):
         self.klass = 'ListModelMixin'
         self.module = 'rest_framework.mixins'
         self.inspector = Inspector(self.klass, self.module)
-        self.assertItemsEqual([x.__name__ for x in
+        self.assertCountEqual([x.__name__ for x in
                                self.inspector.get_children()],
                               ['ListCreateAPIView',
                                'ListAPIView',
@@ -48,7 +48,7 @@ class TestInspector(unittest.TestCase):
         self.klass = 'CreateAPIView'
         self.module = 'rest_framework.generics'
         self.inspector = Inspector(self.klass, self.module)
-        self.assertItemsEqual([x.__name__ for x in
+        self.assertCountEqual([x.__name__ for x in
                               self.inspector.get_direct_ancestors()],
                               ['CreateModelMixin',
                                'GenericAPIView'])
@@ -57,7 +57,7 @@ class TestInspector(unittest.TestCase):
         self.klass = 'ListModelMixin'
         self.module = 'rest_framework.mixins'
         self.inspector = Inspector(self.klass, self.module)
-        self.assertItemsEqual(self.inspector.get_unavailable_methods(),
+        self.assertCountEqual(self.inspector.get_unavailable_methods(),
                               ['filter_queryset', 'get_queryset',
                                'paginate_queryset', 'get_serializer',
                                'get_paginated_response'])

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -11,7 +11,7 @@ from rest_framework_ccbv.config import VERSION
 from rest_framework_ccbv.inspector import Attributes
 
 KLASS_FILE_CONTENT = (
-'{"2.2": {"rest_framework.generics": ["RetrieveDestroyAPIView", "ListAPIView"]},'
+'{"3.2": {"rest_framework.generics": ["RetrieveDestroyAPIView", "ListAPIView"]},'
 '"%s": {"rest_framework.generics": ["RetrieveDestroyAPIView", "ListAPIView"]}}' % VERSION
 )
 
@@ -41,7 +41,7 @@ class TestBasePageRenderer(unittest.TestCase):
         assert context['version']
         assert context['versions']
         assert context['other_versions']
-        assert context['klasses'] == [ListAPIView]
+        assert dict(context['grouped_klasses']) == {"rest_framework.generics": [ListAPIView]}
 
 
 class TestStaticPagesRenderered(unittest.TestCase):
@@ -87,7 +87,7 @@ class TestDetailPageRenderer(unittest.TestCase):
     def test_context(self, get_template_mock):
         self.renderer.render('foo')
         context = get_template_mock.return_value.render.call_args_list[0][0][0]
-        assert context['other_versions'] == ['2.2']
+        assert context['other_versions'] == ['3.2']
         assert context['name'] == ListAPIView.__name__
         assert isinstance(context['ancestors'], (list, tuple))
         assert isinstance(context['direct_ancestors'], (list, tuple))

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -41,7 +41,7 @@ class TestBasePageRenderer(unittest.TestCase):
         assert context['version']
         assert context['versions']
         assert context['other_versions']
-        assert dict(context['grouped_klasses']) == {"rest_framework.generics": [ListAPIView]}
+        assert context['grouped_klasses'] == {"rest_framework.generics": [ListAPIView]}
 
 
 class TestStaticPagesRenderered(unittest.TestCase):

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -2,6 +2,7 @@ import unittest
 
 from mock import mock_open, patch
 from rest_framework.generics import ListAPIView
+from rest_framework.mixins import CreateModelMixin, DestroyModelMixin
 
 from rest_framework_ccbv.renderers import (
     BasePageRenderer, IndexPageRenderer, LandPageRenderer, ErrorPageRenderer,
@@ -18,7 +19,9 @@ KLASS_FILE_CONTENT = (
 
 class TestBasePageRenderer(unittest.TestCase):
     def setUp(self):
-        self.renderer = BasePageRenderer([ListAPIView])
+        self.renderer = BasePageRenderer(
+            [ListAPIView, CreateModelMixin, DestroyModelMixin]
+        )
         self.renderer.template_name = 'base.html'
 
     @patch('rest_framework_ccbv.renderers.BasePageRenderer.get_context', return_value={'foo': 'bar'})
@@ -38,10 +41,13 @@ class TestBasePageRenderer(unittest.TestCase):
         self.renderer.render('foo')
         context = get_template_mock.return_value.render.call_args_list[0][0][0]
         assert context['version_prefix'] == 'Django REST Framework'
-        assert context['version']
+        assert context['version'] == VERSION
         assert context['versions']
         assert context['other_versions']
-        assert context['grouped_klasses'] == {"rest_framework.generics": [ListAPIView]}
+        assert context['grouped_klasses'] == {
+            "rest_framework.generics": [ListAPIView],
+            "rest_framework.mixins": [CreateModelMixin, DestroyModelMixin],
+        }
 
 
 class TestStaticPagesRenderered(unittest.TestCase):


### PR DESCRIPTION
Closes #25 (upgrade to Python 3)
Closes #26 (add pagination classes)
Closes #33 (add 3.11 and 3.12)

We've removed supported for drf <= 3.0 since it required Python/Django versions which are long deprecated.