### PR TITLE
Remove pycrypto

### DIFF
--- a/requirements-tox.txt
+++ b/requirements-tox.txt
@@ -2,4 +2,3 @@ Fabric==2.6.0
 Jinja2==2.11.3
 Pygments==2.8.1
 python-decouple==3.4
-pycrypto==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 Fabric==2.6.0
 python-decouple==3.4
-pycrypto==2.6.1
 tox==3.23.0


### PR DESCRIPTION
Closes #37

https://github.com/vintasoftware/classy-django-rest-framework/security/dependabot/requirements-tox.txt/pycrypto/open

pycrypto seems to be unused on the whole project and it doesn't affect building, so it should be safe to remove it from requirements.