### PR TITLE
Add github secret env to test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Run tests
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           fab coverage
           coveralls


### PR DESCRIPTION
Tests are currently failing with
```
Running on Github Actions but GITHUB_TOKEN is not set. Add "env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" to your step config.
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/coveralls/cli.py", line 64, in main
    coverallz = Coveralls(token_required,
  File "/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/coveralls/api.py", line 49, in __init__
    self.ensure_token()
  File "/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/coveralls/api.py", line 56, in ensure_token
    raise CoverallsException(
coveralls.exception.CoverallsException: Running on Github Actions but GITHUB_TOKEN is not set. Add "env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" to your step config.
```

https://github.com/vintasoftware/classy-django-rest-framework/actions/runs/5611508394/job/15203173298?pr=62