### PR TITLE
Add support for versions 3.15 and 3.16, drop support for versions 3.8 and below

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
     "name": "Cdrf Env",
-    "image": "mcr.microsoft.com/devcontainers/python:0-3.8",
+    "image": "mcr.microsoft.com/devcontainers/python:0-3.10",
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     "forwardPorts": [
         8000

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.13
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.13
+          python-version: 3.10
       - name: Install dependencies
         run: |
           pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.8
+      - name: Set up Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.13
       - name: Install dependencies
         run: |
           pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.8
+      - name: Set up Python 3.13
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.13
       - name: Install dependencies
         run: |
           pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.13
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.13
+          python-version: 3.10
       - name: Install dependencies
         run: |
           pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           pip install --upgrade pip

--- a/build.ini
+++ b/build.ini
@@ -1,44 +1,12 @@
 [tox]
 skipsdist=True
 envlist =
-    drf{31,32,33,34,35,36,37,38,39,310,311,312,313,314},
-    drfbuild{31,32,33,34,35,36,37,38,39,310,311,312,313,314},
+    drf{39,310,311,312,313,314,315,316},
+    drfbuild{39,310,311,312,313,314,315,316},
 
 [testenv]
 deps =
     -r{toxinidir}/requirements-tox.txt
-
-deps31 =
-    django==1.11.29
-    djangorestframework>=3.1,<3.2
-
-deps32 =
-    django==1.11.29
-    djangorestframework>=3.2,<3.3
-
-deps33 =
-    django==1.11.29
-    djangorestframework>=3.3,<3.4
-
-deps34 =
-    django==1.11.29
-    djangorestframework>=3.4,<3.5
-
-deps35 =
-    django==1.11.29
-    djangorestframework>=3.5,<3.6
-
-deps36 =
-    django==1.11.29
-    djangorestframework>=3.6,<3.7
-
-deps37 =
-    django==2.2
-    djangorestframework>=3.7,<3.8
-
-deps38 =
-    django==2.2
-    djangorestframework>=3.8,<3.9
 
 deps39 =
     django==2.2
@@ -64,6 +32,14 @@ deps314 =
     django==4.1.0
     djangorestframework>=3.14,<3.15
 
+deps315 =
+    django==5.2.5
+    djangorestframework>=3.15,<3.16
+
+deps316 =
+    django==5.2.5
+    djangorestframework>=3.16,<3.17
+
 setenv =
     PYTHONPATH = {toxinidir}
 
@@ -77,62 +53,6 @@ commands =
 [build]
 commands =
     fab version
-
-[testenv:drf31]
-deps =
-    {[testenv]deps}
-    {[testenv]deps31}
-commands =
-    {[index]commands}
-
-[testenv:drf32]
-deps =
-    {[testenv]deps}
-    {[testenv]deps32}
-commands =
-    {[index]commands}
-
-[testenv:drf33]
-deps =
-    {[testenv]deps}
-    {[testenv]deps33}
-commands =
-    {[index]commands}
-
-[testenv:drf34]
-deps =
-    {[testenv]deps}
-    {[testenv]deps34}
-commands =
-    {[index]commands}
-
-[testenv:drf35]
-deps =
-    {[testenv]deps}
-    {[testenv]deps35}
-commands =
-    {[index]commands}
-
-[testenv:drf36]
-deps =
-    {[testenv]deps}
-    {[testenv]deps36}
-commands =
-    {[index]commands}
-
-[testenv:drf37]
-deps =
-    {[testenv]deps}
-    {[testenv]deps37}
-commands =
-    {[index]commands}
-
-[testenv:drf38]
-deps =
-    {[testenv]deps}
-    {[testenv]deps38}
-commands =
-    {[index]commands}
 
 [testenv:drf39]
 deps =
@@ -176,72 +96,21 @@ deps =
 commands =
     {[index]commands}
 
+[testenv:drf315]
+deps =
+    {[testenv]deps}
+    {[testenv]deps315}
+commands =
+    {[index]commands}
+
+[testenv:drf316]
+deps =
+    {[testenv]deps}
+    {[testenv]deps316}
+commands =
+    {[index]commands}
 
 # SITE GENERATION
-
-[testenv:drfbuild31]
-deps =
-    {[testenv:drf31]deps}
-envdir =
-    {toxworkdir}/drf31
-commands =
-    {[build]commands}
-
-[testenv:drfbuild32]
-deps =
-    {[testenv:drf32]deps}
-envdir =
-    {toxworkdir}/drf32
-commands =
-    {[build]commands}
-
-[testenv:drfbuild33]
-deps =
-    {[testenv:drf33]deps}
-envdir =
-    {toxworkdir}/drf33
-commands =
-    {[build]commands}
-
-[testenv:drfbuild34]
-deps =
-    {[testenv:drf34]deps}
-envdir =
-    {toxworkdir}/drf34
-commands =
-    {[build]commands}
-
-[testenv:drfbuild35]
-deps =
-    {[testenv:drf35]deps}
-envdir =
-    {toxworkdir}/drf35
-commands =
-    {[build]commands}
-
-[testenv:drfbuild36]
-deps =
-    {[testenv:drf36]deps}
-envdir =
-    {toxworkdir}/drf36
-commands =
-    {[build]commands}
-
-[testenv:drfbuild37]
-deps =
-    {[testenv:drf37]deps}
-envdir =
-    {toxworkdir}/drf37
-commands =
-    {[build]commands}
-
-[testenv:drfbuild38]
-deps =
-    {[testenv:drf38]deps}
-envdir =
-    {toxworkdir}/drf38
-commands =
-    {[build]commands}
 
 [testenv:drfbuild39]
 deps =
@@ -288,5 +157,21 @@ deps =
     {[testenv:drf314]deps}
 envdir =
     {toxworkdir}/drf314
+commands =
+    {[build]commands}
+
+[testenv:drfbuild315]
+deps =
+    {[testenv:drf315]deps}
+envdir =
+    {toxworkdir}/drf315
+commands =
+    {[build]commands}
+
+[testenv:drfbuild316]
+deps =
+    {[testenv:drf316]deps}
+envdir =
+    {toxworkdir}/drf316
 commands =
     {[build]commands}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 -r requirements-tox.txt
-djangorestframework==3.14.0
-django==4.1.13
-pytest==7.1.2
-pytest-cov==4.1.0
-coveralls==3.3.1
+djangorestframework==3.16.0
+django==5.2.5
+pytest==8.4.1
+pytest-cov==6.2.1
+coveralls==4.0.1

--- a/requirements-tox.txt
+++ b/requirements-tox.txt
@@ -1,4 +1,4 @@
-Fabric==2.7.0
-Jinja2==3.1.2
-Pygments==2.15.0
-python-decouple==3.6
+Fabric==3.2.2
+Jinja2==3.1.6
+Pygments==2.19.2
+python-decouple==3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Fabric==2.7.0
-python-decouple==3.6
-tox==3.25.0
+Fabric==3.2.2
+python-decouple==3.8
+tox==4.29.0

--- a/rest_framework_ccbv/config.py
+++ b/rest_framework_ccbv/config.py
@@ -2,20 +2,14 @@ from rest_framework import VERSION as rest_framework_version
 
 
 REST_FRAMEWORK_VERSIONS = [
-    "3.1",
-    "3.2",
-    "3.3",
-    "3.4",
-    "3.5",
-    "3.6",
-    "3.7",
-    "3.8",
     "3.9",
     "3.10",
     "3.11",
     "3.12",
     "3.13",
-    "3.14"
+    "3.14",
+    "3.15",
+    "3.16",
 ]
 
 

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -13,7 +13,7 @@ from rest_framework_ccbv.config import VERSION
 from rest_framework_ccbv.inspector import Attributes
 
 KLASS_FILE_CONTENT = (
-    '{"3.2": {"rest_framework.generics": ["RetrieveDestroyAPIView", "ListAPIView"]},'
+    '{"3.9": {"rest_framework.generics": ["RetrieveDestroyAPIView", "ListAPIView"]},'
     '"%s": {"rest_framework.generics": ["RetrieveDestroyAPIView", "ListAPIView"]}}' % VERSION
 )
 
@@ -98,7 +98,7 @@ class TestDetailPageRenderer(unittest.TestCase):
     def test_context(self, get_template_mock):
         self.renderer.render('foo')
         context = get_template_mock.return_value.render.call_args_list[0][0][0]
-        assert context['other_versions'] == ['3.2']
+        assert context['other_versions'] == ['3.9']
         assert context['name'] == ListAPIView.__name__
         assert isinstance(context['ancestors'], (list, tuple))
         assert isinstance(context['direct_ancestors'], (list, tuple))


### PR DESCRIPTION
## Summary by Sourcery

Update supported Django REST Framework versions and refresh tooling configuration.

New Features:
- Add support for DRF versions 3.15 and 3.16

Enhancements:
- Remove support for DRF versions 3.1–3.8 from tox and config
- Upgrade Fabric, python-decouple, and tox to latest versions
- Update REST_FRAMEWORK_VERSIONS list to include 3.15 and 3.16 and to remove versions 3.8 and below

CI:
- Switch GitHub Actions workflows to use Python 3.10 instead of 3.8

Tests:
- Adjust test_renderers expectations to align with updated version mappings